### PR TITLE
pytest for pre commit et ci

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,102 @@
+name: CI Pipeline
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test_integration:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: Install dependencies
+        run: |
+          pip install pipenv
+          pipenv install --dev
+
+      - name: Run integration tests
+        run: pipenv run pytest tests/test_integration.py
+
+  lint_and_format:
+    runs-on: ubuntu-latest
+    needs: test_integration
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: Install dependencies
+        run: |
+          pip install pipenv
+          pipenv install --dev
+          pip install black pylint
+
+      - name: Run linting
+        run: pipenv run pylint src/*.py
+
+      - name: Run formatting
+        run: pipenv run black --check .
+
+  build_docker:
+    runs-on: ubuntu-latest
+    needs: lint_and_format
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and tag Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: log680equipe6ete24/myapp:latest,log680equipe6ete24/myapp:${{ github.sha }}
+
+  deploy_docker:
+    runs-on: ubuntu-latest
+    needs: build_docker
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: log680equipe6ete24/myapp:latest,log680equipe6ete24/myapp:${{ github.sha }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,8 +26,8 @@ jobs:
           pip install pipenv
           pipenv install --dev
 
-      - name: Run integration tests
-        run: pipenv run pytest tests/test_integration.py
+      - name: Run integration test
+        run: pipenv run pytest test/test_integration.py
 
   lint_and_format:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,10 @@ repos:
     rev: v3.2.5
     hooks:
       - id: pylint
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest test/test_unit.py
+        language: python
+        types: [python]

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ pytest = "*"
 pre-commit = "*"
 pylint = "*"
 black = "*"
+requests-mock = "*"
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5b467bc1d53e583392d76387aeae02b3bb43d524a79ed02551c92c2e55c8e219"
+            "sha256": "ee3f18c4100442eb082364e70680201da52e9f1fce8ab6daaf8e1a6fe91912b2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -506,6 +506,15 @@
             "markers": "python_version >= '3.8'",
             "version": "==2.32.3"
         },
+        "requests-mock": {
+            "hashes": [
+                "sha256:b1e37054004cdd5e56c84454cc7df12b25f90f382159087f4b6915aaeef39563",
+                "sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.5'",
+            "version": "==1.12.1"
+        },
         "signalrcore": {
             "hashes": [
                 "sha256:6d22fdb8ff1e9b51b208841beabc150a58c57e12c6b8c03334cbec8bc2c92712",
@@ -535,7 +544,7 @@
                 "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
                 "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
             ],
-            "markers": "python_version < '3.10'",
+            "markers": "python_version < '3.11'",
             "version": "==4.12.2"
         },
         "urllib3": {
@@ -833,7 +842,7 @@
                 "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
                 "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
             ],
-            "markers": "python_version < '3.10'",
+            "markers": "python_version < '3.11'",
             "version": "==4.12.2"
         },
         "virtualenv": {

--- a/src/main.py
+++ b/src/main.py
@@ -48,7 +48,7 @@ class App:
     def setup_sensor_hub(self):
         """Configure hub connection and subscribe to sensor data events."""
         url = f"{self.host}/SensorHub?token={self.token}"
-        print(f"Connecting to: {url}")  # Debug print
+        print(f"Connecting to: {url}")
         self._hub_connection = (
             HubConnectionBuilder()
             .with_url(url)
@@ -94,7 +94,7 @@ class App:
     def send_action_to_hvac(self, action):
         """Send action query to the HVAC service."""
         response = requests.get(
-            f"{self.host}/api/hvac/{self.token}/{action}/{self.ticks}"
+            f"{self.host}/api/hvac/{self.token}/{action}/{self.ticks}", timeout=10
         )
         details = json.loads(response.text)
         print(details, flush=True)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,0 +1,61 @@
+"""
+Integration tests for the App class in the src.main module.
+"""
+
+import os
+import pytest
+from dotenv import load_dotenv
+import requests_mock
+import psycopg2
+from src.main import App
+
+load_dotenv(dotenv_path=".env.test")
+
+
+@pytest.fixture(scope="module")
+def db_connection():
+    """Fixture for creating a database connection."""
+    conn = psycopg2.connect(os.getenv("DATABASE_URL"))
+    yield conn
+    conn.close()
+
+
+@pytest.fixture(scope="module")
+def app_instance(db_connection):
+    """Fixture for creating an instance of the App class."""
+    app = App()
+    app._db_connection = db_connection
+    return app
+
+
+@pytest.fixture
+def mock_requests():
+    """Fixture for mocking HTTP requests."""
+    with requests_mock.Mocker() as m:
+        yield m
+
+
+def test_sensor_data_received(db_connection, app_instance, mock_requests):
+    """Test receiving sensor data and saving it to the database."""
+    mock_requests.get(
+        f"{app_instance.host}/api/hvac/{app_instance.token}/TurnOnAc/{app_instance.ticks}",
+        text='{"status": "success"}',
+    )
+    mock_requests.get(
+        f"{app_instance.host}/api/hvac/{app_instance.token}/TurnOnHeater/{app_instance.ticks}",
+        text='{"status": "success"}',
+    )
+
+    sensor_data = [{"date": "2024-07-01T12:00:00Z", "data": "35"}]
+    app_instance.on_sensor_data_received(sensor_data)
+
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "SELECT timestamp, temperature, event FROM oxygen_temperatures WHERE timestamp = %s",
+            ("2024-07-01T12:00:00Z",),
+        )
+        result = cur.fetchone()
+        assert result is not None
+        assert result[0].isoformat() == "2024-07-01T12:00:00"
+        assert result[1] == 35.0
+        assert result[2] == "TurnOnAc"


### PR DESCRIPTION
### Description
Mise en place d'un pipeline d'intégration continue pour l'application Oxygen CS.

### Changements
- Ajout d'un fichier .github/workflows/ci.yml pour configurer GitHub Actions.
  - Configuration du pipeline pour :
  - Lancer les tests d'intégration (pas les tests unitaires) de l'application.
  - Effectuer les étapes de linting et de formatage.
  - Construire l'image Docker seulement lorsque les changements sont sur la branche main.
  - Taguer l'image Docker avec latest et un autre identifiant (version de l'application, build id, etc.).
  - Déployer l'image Docker sur DockerHub seulement lorsqu'il y a des changements sur la branche main.
- Ajout de pytest pour les hooks pre-commit pour exécuter les tests unitaires.

### Lien vers carte(s) du tableau Kanban
[Issue 47](https://github.com/FilGoodInc/metrics-e24-grp1-eq6/issues/47)
### Autheur
Ramy Ouabel